### PR TITLE
Fix descr accessor

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+	- Fixes descr accessor [preserve legacy desc]
+
 0.44      2018-07-13 17:32:55-06:00 America/Denver
 
     - Adjust duplicate copyrights

--- a/lib/Net/Whois/IANA.pm
+++ b/lib/Net/Whois/IANA.pm
@@ -45,7 +45,7 @@ BEGIN {
     # accessors
     # do not use AUTOLOAD - only accept lowercase function name
     # define accessors at compile time
-    my @accessors = qw{country netname desc status source server inetnum inet6num cidr};
+    my @accessors = qw{country netname descr status source server inetnum inet6num cidr};
 
     foreach my $accessor (@accessors) {
         no strict 'refs';
@@ -56,6 +56,8 @@ BEGIN {
             return $self->{QUERY}->{$accessor};
         };
     }
+
+    *desc = \&descr; # backward compatibility
 }
 
 our @EXPORT = qw( @IANA %IANA );

--- a/t/accessors.t
+++ b/t/accessors.t
@@ -1,0 +1,25 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 9;
+use Net::Whois::IANA;
+
+my $iana = Net::Whois::IANA->new;
+my $ip   = '193.0.0.135';
+
+$iana->whois_query( -ip => $ip, -whois => 'ripe' );
+
+isa_ok $iana, 'Net::Whois::IANA';
+
+is( $iana->country(), 'NL',       'country' );
+is( $iana->netname(), 'RIPE-NCC', 'netname' );
+like( $iana->descr(), qr{RIPE Network}, "descr" );
+is( $iana->desc(), $iana->descr(), "desc - backward compatible" );
+is( $iana->status(), 'ASSIGNED PA', 'status' );
+is( $iana->source(), 'RIPE RIPE',   'source' );
+is( $iana->server(), 'RIPE',        'server' );
+ok( $iana->inetnum(), 'inetnum' );
+
+#is( $iana->inet6num(), 'NL', 'inet6num' );


### PR DESCRIPTION
Fixes #11

To access to desc the accessor should be named descr
otherwise it's always going to return undef.