### PR TITLE
Fix t/60-cidrvalidate.t test

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    - Fix t/60-cidrvalidate.t
+
 0.47      2021-10-04 10:33:55-06:00 America/Denver
 
     - Reformat POD to avoid verbatim blocks

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,7 +36,7 @@ my %WriteMakefileArgs = (
     "Test::MockModule" => "0.175",
     "Test::More" => 0
   },
-  "VERSION" => "0.47",
+  "VERSION" => "0.48",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Net::Whois::IANA - Net::Whois::IANA - A universal WHOIS data extractor.
 
 # VERSION
 
-version 0.47
+version 0.48
 
 # SYNOPSIS
 

--- a/t/60-cidrvalidate.t
+++ b/t/60-cidrvalidate.t
@@ -10,6 +10,27 @@ use Test2::Plugin::NoWarnings;
 use Net::CIDR;
 use Net::Whois::IANA;
 
+use Test::MockModule;
+
+# note: we are mocking some internal to freeze the ripe reply
+my $mocked_iana = Test::MockModule->new('Net::Whois::IANA');
+
+$mocked_iana->redefine(
+    source_connect => sub {
+        my ( $self, $source_name ) = @_;
+
+        note "mocked source_connect for ", $source_name;
+        my $sock = $mocked_iana->original('source_connect')->( $self, $source_name );
+
+        $self->{query_sub} = sub {
+            return %{ _ripe_query() } if $source_name eq 'ripe';
+            return ();
+        };
+
+        return $sock;
+    }
+);
+
 my $iana = Net::Whois::IANA->new;
 
 ok $iana;
@@ -26,7 +47,7 @@ if ($cidr) {    # some smokers are flapping... this is kind of a big todo...
 
     if ( defined $cidr->[0] ) {    # query can fail on some smokers...
 
-        like $cidr->[0], qr{^191\.96\.58(\.0)?/24}, 'cidr';
+        like $cidr->[0], qr{^\Q191.96.0.0/16\E}, 'cidr';
 
         # view on travis smoker this can be either 191.96.58/24 or 191.96.58-191.96.58...
         ### need to investigate
@@ -38,3 +59,60 @@ if ($cidr) {    # some smokers are flapping... this is kind of a big todo...
 }
 
 done_testing;
+exit;
+
+sub _ripe_query {
+    return {
+        'abuse-c'  => 'IPXO834',
+        'admin-c'  => 'CYB777',
+        'cidr'     => ['191.96.0.0/16'],
+        'country'  => 'AE',
+        'created'  => '2022-03-02T14:23:29Z',
+        'fullinfo' => '% This is the RIPE Database query service.
+    % The objects are in RPSL format.
+    %
+    % The RIPE Database is subject to Terms and Conditions.
+    % See http://www.ripe.net/db/support/db-terms-conditions.pdf
+
+    % Note: this output has been filtered.
+    %       To receive output for a database update, use the "-B" flag.
+
+    % Information related to \'191.96.0.0 - 191.96.255.255\'
+
+    % Abuse contact for \'191.96.0.0 - 191.96.255.255\' is \'abuse@ipxo.com\'
+
+    inetnum:        191.96.0.0 - 191.96.255.255
+    netname:        AE-CYBERASSETS-20131024
+    country:        AE
+    org:            ORG-CAF4-RIPE
+    admin-c:        CYB777
+    tech-c:         CYB777
+    abuse-c:        IPXO834
+    mnt-lower:      IPXO-MNT
+    mnt-domains:    IPXO-MNT
+    mnt-routes:     IPXO-MNT
+    status:         ALLOCATED PA
+    mnt-by:         CYBER-A-MNT
+    mnt-by:         RIPE-NCC-HM-MNT
+    created:        2022-03-02T14:23:29Z
+    last-modified:  2022-03-02T14:29:23Z
+    source:         RIPE
+
+    % This query was served by the RIPE Database Query Service version 1.102.2 (ANGUS)
+
+
+    ',
+        'inetnum'       => '191.96.0.0 - 191.96.255.255',
+        'last-modified' => '2022-03-02T14:29:23Z',
+        'mnt-by'        => 'CYBER-A-MNT RIPE-NCC-HM-MNT',
+        'mnt-domains'   => 'IPXO-MNT',
+        'mnt-lower'     => 'IPXO-MNT',
+        'mnt-routes'    => 'IPXO-MNT',
+        'netname'       => 'AE-CYBERASSETS-20131024',
+        'org'           => 'ORG-CAF4-RIPE',
+        'permission'    => 'allowed',
+        'source'        => 'RIPE',
+        'status'        => 'ALLOCATED PA',
+        'tech-c'        => 'CYB777'
+    };
+}


### PR DESCRIPTION
Fix #18

    The test t/60-cidrvalidate.t was an integration test
    and relies on ripe answer.

    As this could change over time and already created several
    issues. Let's mock the 'query_sub' and control our own answer.